### PR TITLE
fix count of remaining records to seed

### DIFF
--- a/fakegoose.js
+++ b/fakegoose.js
@@ -143,7 +143,7 @@ function seed(model, count, forceAppend, callback) {
   if(forceAppend) return _seed(model, count, callback);
   model.count(function(error, total) {
     if(error) return callback(error);
-    var remainder = Math.max(0, total - count);
+    var remainder = Math.max(0, count - total);
     if(!remainder) return callback(null);
     _seed(model, remainder, callback);
   });


### PR DESCRIPTION
Seed won't properly calculate the remaining records to seed if forceAppend=false thus not creating any due to a clear programming mistake.